### PR TITLE
chore: Cloud Agent dev environment (install/start scripts)

### DIFF
--- a/.cursor/ensure-api-env.sh
+++ b/.cursor/ensure-api-env.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Ensure the Laravel API (and, when possible, the web apps) have a usable .env.
+#
+# The real per-app config lives in encrypted .envx.local files. When the
+# DOTENV_PRIVATE_KEY_LOCAL secret is present we decrypt those to .env. When it
+# is not (e.g. a fresh Cloud Agent without the secret configured), we still want
+# a working dev environment, so we write a functional local .env for the API
+# using non-sensitive local defaults that match the natively-run services
+# (MariaDB `primary`, Redis with password, Mailpit). Production/build-only
+# secrets (Sentry, Resend, Turbo) are intentionally omitted — local dev does
+# not need them.
+#
+# The Next.js apps read every variable as optional (see apps/*/src/env.ts), so
+# they run fine without a .env when the key is absent.
+#
+# Safe to run repeatedly (idempotent).
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Make mise-managed node/pnpm available in non-login shells (needed for dotenvx).
+if [[ -x "${HOME}/.local/bin/mise" ]]; then
+  eval "$("${HOME}/.local/bin/mise" activate bash)" 2>/dev/null || true
+  export PATH="${HOME}/.local/share/mise/shims:${PATH}"
+fi
+
+log() { printf '[env] %s\n' "$1"; }
+
+API_ENV="apps/api/.env"
+
+if [[ -n "${DOTENV_PRIVATE_KEY_LOCAL:-}" ]]; then
+  log "DOTENV_PRIVATE_KEY_LOCAL present — decrypting .envx.local for api, main, codehouse…"
+  for app in api main codehouse; do
+    pnpm --filter "${app}" env:use:local
+  done
+elif [[ ! -f "${API_ENV}" ]]; then
+  log "No DOTENV_PRIVATE_KEY_LOCAL and no apps/api/.env — writing a local dev fallback…"
+  cat > "${API_ENV}" <<'ENV'
+# Generated local dev fallback (no DOTENV_PRIVATE_KEY_LOCAL available).
+# Matches the natively-run MariaDB/Redis/Mailpit services. Set the
+# DOTENV_PRIVATE_KEY_LOCAL secret to instead decrypt the canonical .envx.local.
+APP_NAME="Sander Cokart"
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_TIMEZONE=UTC
+APP_URL=http://127.0.0.1:8000
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+
+APP_MAINTENANCE_DRIVER=file
+
+BCRYPT_ROUNDS=12
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+DB_CONNECTION=mariadb
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=primary
+DB_USERNAME=
+DB_PASSWORD=
+
+SESSION_DRIVER=redis
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=localhost
+
+BROADCAST_CONNECTION=log
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=database
+
+CACHE_STORE=redis
+CACHE_PREFIX=
+
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=password
+REDIS_PORT=6379
+
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+
+MAIL_TO_ADDRESS="contact@example.com"
+MAIL_TO_NAME="Sander Cokart"
+
+VITE_APP_NAME="${APP_NAME}"
+ENV
+else
+  log "apps/api/.env already present — leaving it as is."
+fi
+
+if [[ -f "${API_ENV}" ]] && ! grep -qE '^APP_KEY=base64:' "${API_ENV}"; then
+  log "Generating Laravel APP_KEY…"
+  (cd apps/api && php artisan key:generate --force --ansi)
+fi

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent environment — install phase (idempotent).
+#
+# Refreshes source-derived dependencies after the repository is checked out:
+#   - JavaScript/TypeScript workspace dependencies (pnpm)
+#   - Laravel API PHP dependencies (composer, via the api package postinstall)
+#   - Decrypted per-app .env files (when DOTENV_PRIVATE_KEY_LOCAL is available)
+#   - Built output for internal packages that ship a dist/ (runtime-env, toolbox)
+#
+# System packages (PHP 8.5, Node, pnpm, MariaDB, Redis, Mailpit) come from the
+# base snapshot. Long-running services and migrations live in start.sh.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+log() { printf '[install] %s\n' "$1"; }
+
+log "Installing workspace dependencies (pnpm)…"
+pnpm install --config.confirmModulesPurge=false
+
+if [[ -n "${DOTENV_PRIVATE_KEY_LOCAL:-}" ]]; then
+  log "Decrypting local env files for api, main, codehouse…"
+  for app in api main codehouse; do
+    pnpm --filter "${app}" env:use:local
+  done
+else
+  log "DOTENV_PRIVATE_KEY_LOCAL not set — keeping existing .env files (add it as a secret to refresh them)."
+fi
+
+log "Building internal dist packages (runtime-env, toolbox)…"
+pnpm exec turbo run build --filter=@repo/runtime-env --filter=@repo/toolbox
+
+if [[ -f apps/api/.env ]]; then
+  if ! grep -qE '^APP_KEY=base64:' apps/api/.env; then
+    log "Generating Laravel APP_KEY…"
+    (cd apps/api && php artisan key:generate --force --ansi)
+  fi
+fi
+
+log "Install complete."

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -17,26 +17,19 @@ cd "${REPO_ROOT}"
 
 log() { printf '[install] %s\n' "$1"; }
 
+# Make mise-managed node/pnpm available in non-login shells.
+if [[ -x "${HOME}/.local/bin/mise" ]]; then
+  eval "$("${HOME}/.local/bin/mise" activate bash)" 2>/dev/null || true
+  export PATH="${HOME}/.local/share/mise/shims:${PATH}"
+fi
+
 log "Installing workspace dependencies (pnpm)…"
 pnpm install --config.confirmModulesPurge=false
 
-if [[ -n "${DOTENV_PRIVATE_KEY_LOCAL:-}" ]]; then
-  log "Decrypting local env files for api, main, codehouse…"
-  for app in api main codehouse; do
-    pnpm --filter "${app}" env:use:local
-  done
-else
-  log "DOTENV_PRIVATE_KEY_LOCAL not set — keeping existing .env files (add it as a secret to refresh them)."
-fi
+log "Ensuring API .env (decrypt with key, else local fallback)…"
+bash .cursor/ensure-api-env.sh
 
 log "Building internal dist packages (runtime-env, toolbox)…"
 pnpm exec turbo run build --filter=@repo/runtime-env --filter=@repo/toolbox
-
-if [[ -f apps/api/.env ]]; then
-  if ! grep -qE '^APP_KEY=base64:' apps/api/.env; then
-    log "Generating Laravel APP_KEY…"
-    (cd apps/api && php artisan key:generate --force --ansi)
-  fi
-fi
 
 log "Install complete."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent environment — start phase (idempotent, per-boot).
+#
+# Brings up the backing services the Laravel API expects for local dev:
+#   - MariaDB   (127.0.0.1:3306, databases `primary` + `testing`)
+#   - Redis     (127.0.0.1:6379, requirepass "password")
+#   - Mailpit   (SMTP 127.0.0.1:1025, web UI 127.0.0.1:8025)
+#
+# It also maps the docker-compose service hostnames (db, redis, mailpit) to
+# loopback so the decrypted .env (MAIL_HOST=mailpit) and phpunit.xml
+# (DB_HOST=db) resolve without Docker, then runs pending migrations.
+#
+# The dev servers themselves (api, codehouse, main) run as persistent
+# terminals, not here. This script starts daemons, checks readiness, returns.
+set -uo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+log() { printf '[start] %s\n' "$1"; }
+
+# 1. Map compose service hostnames to loopback (best effort).
+if ! grep -qE '^127\.0\.0\.1[[:space:]].*\bmailpit\b' /etc/hosts 2>/dev/null; then
+  echo '127.0.0.1 db redis mailpit' | sudo tee -a /etc/hosts >/dev/null 2>&1 || \
+    log "warning: could not update /etc/hosts (mailpit/db hostname mapping)"
+fi
+
+# 2. Redis (password-protected to match REDIS_PASSWORD).
+if ! redis-cli -a password -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+  log "Starting Redis…"
+  sudo redis-server --daemonize yes --requirepass password --port 6379 --bind 127.0.0.1
+fi
+
+# 3. MariaDB.
+if ! sudo mariadb -e 'SELECT 1' >/dev/null 2>&1; then
+  log "Starting MariaDB…"
+  sudo mkdir -p /var/run/mysqld && sudo chown mysql:mysql /var/run/mysqld
+  sudo bash -c 'nohup mariadbd-safe >/var/log/mariadb-boot.log 2>&1 &'
+  for _ in $(seq 1 60); do
+    sudo mariadb -e 'SELECT 1' >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
+
+if sudo mariadb -e 'SELECT 1' >/dev/null 2>&1; then
+  log "Ensuring databases and anonymous dev user exist…"
+  sudo mariadb <<'SQL' || log "warning: MariaDB bootstrap SQL failed"
+CREATE DATABASE IF NOT EXISTS `primary` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE IF NOT EXISTS `testing` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS ''@'localhost' IDENTIFIED BY '';
+CREATE USER IF NOT EXISTS ''@'127.0.0.1' IDENTIFIED BY '';
+CREATE USER IF NOT EXISTS ''@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON `primary`.* TO ''@'localhost', ''@'127.0.0.1', ''@'%';
+GRANT ALL PRIVILEGES ON `testing`.* TO ''@'localhost', ''@'127.0.0.1', ''@'%';
+FLUSH PRIVILEGES;
+SQL
+else
+  log "warning: MariaDB is not reachable; skipping database bootstrap and migrations"
+fi
+
+# 4. Mailpit.
+if ! pgrep -x mailpit >/dev/null 2>&1; then
+  log "Starting Mailpit…"
+  nohup mailpit --smtp 0.0.0.0:1025 --listen 0.0.0.0:8025 >/tmp/mailpit.log 2>&1 &
+fi
+
+# 5. Run pending migrations against the dev database.
+if [[ -f apps/api/.env ]] && sudo mariadb -e 'SELECT 1' >/dev/null 2>&1; then
+  log "Running database migrations…"
+  (cd apps/api && php artisan migrate --force --graceful --ansi) || \
+    log "warning: migrations did not complete"
+fi
+
+log "Start complete."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -20,6 +20,12 @@ cd "${REPO_ROOT}"
 
 log() { printf '[start] %s\n' "$1"; }
 
+# 0. Ensure the API .env exists on every boot (decrypt with the secret when
+#    available, otherwise write a working local dev fallback). This runs here —
+#    not just in install — because a checkout can drop the gitignored .env and
+#    the install phase may be skipped on warm boots.
+bash .cursor/ensure-api-env.sh || log "warning: could not ensure apps/api/.env"
+
 # 1. Map compose service hostnames to loopback (best effort).
 if ! grep -qE '^127\.0\.0\.1[[:space:]].*\bmailpit\b' /etc/hosts 2>/dev/null; then
   echo '127.0.0.1 db redis mailpit' | sudo tee -a /etc/hosts >/dev/null 2>&1 || \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for the monorepo. No Docker is required for dev — the Laravel API runs via `php artisan serve`, the two Next.js sites via `next dev`, and the backing services (MariaDB, Redis, Mailpit) run natively on the ports the `.envx.local` config expects. The environment itself (base snapshot + install/start) is configured via the Cloud Agent dashboard; this PR adds the equivalent setup logic as reviewable, reusable scripts.

## What runs

- `apps/main` (Next.js) — http://localhost:3000
- `apps/codehouse` (Next.js) — http://localhost:3001
- `apps/api` (Laravel 12 / PHP 8.5) — http://localhost:8000, health at `/health`, `POST /v1/contact`
- MariaDB `127.0.0.1:3306` (databases `primary` + `testing`), Redis `127.0.0.1:6379`, Mailpit SMTP `1025` / UI `8025`

## Changes (`.cursor/`)

- `install.sh` — idempotent install: `pnpm install` (also runs the API's Composer install via its `postinstall`), ensures the API `.env` (see below), and builds the internal `dist` packages (`@repo/runtime-env`, `@repo/toolbox`).
- `start.sh` — idempotent per-boot: ensures the API `.env`, maps compose hostnames (`db`, `redis`, `mailpit`) to loopback so the local config resolves without Docker, starts MariaDB / Redis / Mailpit, ensures the `primary`/`testing` databases + anonymous dev user exist, and runs pending migrations.
- `ensure-api-env.sh` — decrypts the canonical `.envx.local` when `DOTENV_PRIVATE_KEY_LOCAL` is present, otherwise writes a functional local-dev fallback `apps/api/.env` (non-secret local defaults matching the native services) so the API works even without the secret.

## How it was validated

Full stack verified end-to-end on the VM and again in a fresh Cloud Agent booted from a prebuilt environment build: toolchain versions (Node 22.19.0 / pnpm 10.32.1 / PHP 8.5.9 / Composer), both Next.js sites returning 200 with real content, the API health check, the `POST /v1/contact` → Mailpit email flow (HTTP 204 + delivered), and the API Feature suite (11 passed). `pnpm lint` is clean (0 errors).

## Notes

- The saved Cloud Agent environment uses install/start logic equivalent to these scripts. They also serve as local-dev helpers (`bash .cursor/start.sh`).
- `DOTENV_PRIVATE_KEY_LOCAL` can optionally be added as a Cursor **Secret** to decrypt the canonical `.envx.local` instead of using the local fallback. The environment works either way.
- No application code changed; decrypted/generated `.env` files remain gitignored.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0a39a52-69eb-49a2-816b-92f0902666c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0a39a52-69eb-49a2-816b-92f0902666c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

