### PR TITLE
#12 | Upgrade next-intl to 4.13.6 and migrate to next/root-params

### DIFF
--- a/apps/codehouse/package.json
+++ b/apps/codehouse/package.json
@@ -33,7 +33,7 @@
     "lucide-react": "^0.577.0",
     "motion": "^12.38.0",
     "next": "16.3.0",
-    "next-intl": "4.13.0",
+    "next-intl": "4.13.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-error-boundary": "^4.1.2",
@@ -43,7 +43,7 @@
     "require-in-the-middle": "8.0.1",
     "sharp": "0.34.5",
     "tailwind-merge": "^3.5.0",
-    "use-intl": "^4.13.0",
+    "use-intl": "^4.13.6",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/codehouse/src/app/[locale]/(root)/layout.tsx
+++ b/apps/codehouse/src/app/[locale]/(root)/layout.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
+import { getLocale } from 'next-intl/server';
 
-import type { LocaleCode } from '@/src/i18n/config';
+import type { ReactNode } from 'react';
 
 import { CachedPageContent } from '../_ppr/cached-page-content';
 
@@ -8,11 +8,10 @@ import { Header } from './(components)/header';
 
 type RootRouteLayoutProps = {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 };
 
-export default async function RootRouteLayout({ children, params }: RootRouteLayoutProps) {
-  const { locale } = (await params) as { locale: LocaleCode };
+export default async function RootRouteLayout({ children }: RootRouteLayoutProps) {
+  const locale = await getLocale();
 
   return (
     <>

--- a/apps/codehouse/src/app/[locale]/(root)/page.tsx
+++ b/apps/codehouse/src/app/[locale]/(root)/page.tsx
@@ -1,14 +1,6 @@
-import { setRequestLocale } from 'next-intl/server';
-
 import { ServiceOfferingsSection } from './(components)/service-offerings-section';
-import { LocaleCode } from '@/src/i18n/config';
 
-type LandingPageParams = { params: Promise<{ locale: string }> };
-
-export default async function LandingPage({ params }: LandingPageParams) {
-  const { locale } = (await params) as { locale: LocaleCode };
-  setRequestLocale(locale);
-
+export default function LandingPage() {
   return (
     <main className="flex grow flex-col">
       <ServiceOfferingsSection />

--- a/apps/codehouse/src/app/[locale]/(routes)/commercial/layout.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/commercial/layout.tsx
@@ -1,17 +1,17 @@
+import { getLocale } from 'next-intl/server';
+
 import type { ReactNode } from 'react';
 
 import { ServiceHeader } from '@/src/components/service-header';
-import type { LocaleCode } from '@/src/i18n/config';
 
 import { CachedPageContent } from '../../_ppr/cached-page-content';
 
 type CommercialLayoutProps = {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 };
 
-export default async function CommercialLayout({ children, params }: CommercialLayoutProps) {
-  const { locale } = (await params) as { locale: LocaleCode };
+export default async function CommercialLayout({ children }: CommercialLayoutProps) {
+  const locale = await getLocale();
 
   return (
     <>

--- a/apps/codehouse/src/app/[locale]/(routes)/commercial/page.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/commercial/page.tsx
@@ -1,7 +1,4 @@
-import { setRequestLocale } from 'next-intl/server';
-
 import { Line } from '@/src/components/line';
-import type { LocaleCode } from '@/src/i18n/config';
 
 import { AskForAQuote } from '../consumer/(sections)/ask-for-a-quote';
 
@@ -14,12 +11,7 @@ import { CommercialNumbersSection } from './(sections)/commercial-numbers-sectio
 import { CommercialScaleSection } from './(sections)/commercial-scale-section';
 import { CommercialTrustSection } from './(sections)/commercial-trust-section';
 
-type PageParams = { params: Promise<{ locale: string }> };
-
-export default async function Page({ params }: PageParams) {
-  const { locale } = (await params) as { locale: LocaleCode };
-  setRequestLocale(locale);
-
+export default function Page() {
   return (
     <main className="grow">
       <CommercialHeroSection />

--- a/apps/codehouse/src/app/[locale]/(routes)/consumer/layout.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/consumer/layout.tsx
@@ -1,17 +1,17 @@
+import { getLocale } from 'next-intl/server';
+
 import type { ReactNode } from 'react';
 
 import { ServiceHeader } from '@/src/components/service-header';
-import type { LocaleCode } from '@/src/i18n/config';
 
 import { CachedPageContent } from '../../_ppr/cached-page-content';
 
 type ConsumerLayoutProps = {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 };
 
-export default async function ConsumerLayout({ children, params }: ConsumerLayoutProps) {
-  const { locale } = (await params) as { locale: LocaleCode };
+export default async function ConsumerLayout({ children }: ConsumerLayoutProps) {
+  const locale = await getLocale();
 
   return (
     <>

--- a/apps/codehouse/src/app/[locale]/(routes)/consumer/page.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/consumer/page.tsx
@@ -1,19 +1,11 @@
-import { setRequestLocale } from 'next-intl/server';
-
 import { Line } from '@/src/components/line';
-import { LocaleCode } from '@/src/i18n/config';
 
 import { AskForAQuote } from './(sections)/ask-for-a-quote';
 import { ConsumersHeroSection } from './(sections)/consumers-hero-section';
 import { ConsumersTestimonialsSection } from './(sections)/consumers-testimonials-section';
 import { ConsumersWhyChooseSection } from './(sections)/consumers-why-choose-section';
 
-type ConsumerPageParams = { params: Promise<{ locale: string }> };
-
-export default async function Page({ params }: ConsumerPageParams) {
-  const { locale } = (await params) as { locale: LocaleCode };
-  setRequestLocale(locale);
-
+export default function Page() {
   return (
     <main className="grow">
       <ConsumersHeroSection />

--- a/apps/codehouse/src/app/[locale]/(routes)/freelance/layout.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/freelance/layout.tsx
@@ -1,17 +1,17 @@
+import { getLocale } from 'next-intl/server';
+
 import type { ReactNode } from 'react';
 
 import { ServiceHeader } from '@/src/components/service-header';
-import type { LocaleCode } from '@/src/i18n/config';
 
 import { CachedPageContent } from '../../_ppr/cached-page-content';
 
 type FreelanceLayoutProps = {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 };
 
-export default async function FreelanceLayout({ children, params }: FreelanceLayoutProps) {
-  const { locale } = (await params) as { locale: LocaleCode };
+export default async function FreelanceLayout({ children }: FreelanceLayoutProps) {
+  const locale = await getLocale();
 
   return (
     <>

--- a/apps/codehouse/src/app/[locale]/(routes)/freelance/page.tsx
+++ b/apps/codehouse/src/app/[locale]/(routes)/freelance/page.tsx
@@ -1,7 +1,4 @@
-import { setRequestLocale } from 'next-intl/server';
-
 import { Line } from '@/src/components/line';
-import type { LocaleCode } from '@/src/i18n/config';
 
 import { AskForAQuote } from '../consumer/(sections)/ask-for-a-quote';
 
@@ -11,12 +8,7 @@ import { FreelanceShowcaseSection } from './(sections)/freelance-showcase-sectio
 import { FreelanceSkillsSection } from './(sections)/freelance-skills-section';
 import { FreelanceTechIndexSection } from './(sections)/freelance-tech-index-section';
 
-type PageParams = { params: Promise<{ locale: string }> };
-
-export default async function Page({ params }: PageParams) {
-  const { locale } = (await params) as { locale: LocaleCode };
-  setRequestLocale(locale);
-
+export default function Page() {
   return (
     <main className="grow">
       <FreelanceHeroSection />

--- a/apps/codehouse/src/app/[locale]/[...rest]/page.tsx
+++ b/apps/codehouse/src/app/[locale]/[...rest]/page.tsx
@@ -1,14 +1,5 @@
-import { setRequestLocale } from 'next-intl/server';
-
 import { notFound } from 'next/navigation';
 
-export default async function CatchAllPage(props: {
-  params: Promise<{
-    locale: string;
-  }>;
-}) {
-  const { locale } = (await props.params) as { locale: 'en' | 'nl' };
-
-  setRequestLocale(locale);
+export default function CatchAllPage() {
   notFound();
 }

--- a/apps/codehouse/src/app/[locale]/layout.tsx
+++ b/apps/codehouse/src/app/[locale]/layout.tsx
@@ -2,9 +2,7 @@ import './globals.css';
 
 import { EnvScript } from '@repo/runtime-env/env-script';
 import { cn } from '@repo/ui/lib/utils';
-import { hasLocale } from 'next-intl';
-import { setRequestLocale } from 'next-intl/server';
-import { notFound } from 'next/navigation';
+import { getLocale } from 'next-intl/server';
 
 import { Suspense } from 'react';
 import { Geist, Geist_Mono } from 'next/font/google';
@@ -14,7 +12,6 @@ import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 
 import { env } from '@/src/env';
-import { LocaleCode } from '@/src/i18n/config';
 import { routing } from '@/src/i18n/routing';
 import { GlobalProviders } from '@/src/providers/server.global-providers';
 
@@ -82,12 +79,12 @@ const bodyClassName = cn(
   'mb-14 lg:mb-0', // account for mobile navigation @see <Navigation />
 );
 
-type RootLayoutParams = { children: ReactNode; params: Promise<{ locale: string }> };
+type RootLayoutParams = { children: ReactNode };
 
-export default function RootLayout({ params, children }: RootLayoutParams) {
+export default function RootLayout({ children }: RootLayoutParams) {
   return (
     <Suspense fallback={<RootLayoutFallback>{children}</RootLayoutFallback>}>
-      <LocalizedRootLayout params={params}>{children}</LocalizedRootLayout>
+      <LocalizedRootLayout>{children}</LocalizedRootLayout>
     </Suspense>
   );
 }
@@ -114,14 +111,8 @@ function RootLayoutFallback({ children }: { children: ReactNode }) {
   );
 }
 
-async function LocalizedRootLayout({ params, children }: RootLayoutParams) {
-  const { locale } = (await params) as { locale: LocaleCode };
-
-  if (!hasLocale(routing.locales, locale)) {
-    notFound();
-  }
-
-  setRequestLocale(locale);
+async function LocalizedRootLayout({ children }: RootLayoutParams) {
+  const locale = await getLocale();
 
   return (
     <html suppressHydrationWarning className="relative scroll-smooth" data-scroll-behavior="smooth" lang={locale}>

--- a/apps/codehouse/src/components/locale-switcher.tsx
+++ b/apps/codehouse/src/components/locale-switcher.tsx
@@ -4,32 +4,32 @@ import { cn } from '@repo/ui/lib/utils';
 import { GB as GBFlag, NL as NLFlag } from 'country-flag-icons/react/3x2';
 import { useLocale } from 'next-intl';
 
-import { LocaleCode } from '@/src/i18n/config';
 import { Link, usePathname } from '@/src/i18n/navigation';
 
 export function LocaleSwitcher() {
+  // next-intl's usePathname already includes a leading `/` and omits the locale prefix.
   const pathname = usePathname();
-  const active_locale = useLocale() as LocaleCode;
+  const activeLocale = useLocale();
 
   return (
     <div
       className={cn(
         'pointer-events-none flex min-w-[94px] justify-center gap-2 [&_svg]:pointer-events-auto [&:hover_svg]:opacity-50 [&:hover_svg:hover]:opacity-100',
       )}>
-      <Link replace href={`/${pathname}`} hrefLang="en" locale="en" rel="alternate" scroll={false}>
+      <Link replace href={pathname} hrefLang="en" locale="en" rel="alternate" scroll={false}>
         <GBFlag
           className={cn('h-5 cursor-pointer transition-opacity sm:h-7', {
-            'opacity-50': active_locale !== 'en',
-            'cursor-not-allowed': active_locale === 'en',
+            'opacity-50': activeLocale !== 'en',
+            'cursor-not-allowed': activeLocale === 'en',
           })}
         />
       </Link>
       <div className="h-5 border-r-2 border-white !opacity-100 sm:h-7" />
-      <Link replace href={`/${pathname}`} hrefLang="nl" locale="nl" rel="alternate" scroll={false}>
+      <Link replace href={pathname} hrefLang="nl" locale="nl" rel="alternate" scroll={false}>
         <NLFlag
           className={cn('h-5 cursor-pointer transition-opacity sm:h-7', {
-            'opacity-50': active_locale !== 'nl',
-            'cursor-not-allowed': active_locale === 'nl',
+            'opacity-50': activeLocale !== 'nl',
+            'cursor-not-allowed': activeLocale === 'nl',
           })}
         />
       </Link>

--- a/apps/codehouse/src/i18n/request.ts
+++ b/apps/codehouse/src/i18n/request.ts
@@ -1,19 +1,25 @@
 import { hasLocale } from 'next-intl';
 import { getRequestConfig } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import * as rootParams from 'next/root-params';
 
 import { routing } from './routing';
 
-export default getRequestConfig(async ({ requestLocale }) => {
-  const requested = await requestLocale;
+export default getRequestConfig(async ({ locale }) => {
+  // Explicit locale overrides (e.g. Server Actions / Route Handlers) take precedence;
+  // otherwise read the `[locale]` root param via next/root-params.
+  if (!locale) {
+    const paramValue = await rootParams.locale();
 
-  // if (!hasLocale(routing.locales, locale)) {
-  //   notFound();
-  // }
-
-  const resolvedLocale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
+    if (hasLocale(routing.locales, paramValue)) {
+      locale = paramValue;
+    } else {
+      notFound();
+    }
+  }
 
   return {
-    locale: resolvedLocale,
-    messages: (await import(`../../messages/${resolvedLocale}.json`)).default,
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
   };
 });

--- a/apps/codehouse/src/proxy.ts
+++ b/apps/codehouse/src/proxy.ts
@@ -1,11 +1,20 @@
 import createMiddleware from 'next-intl/middleware';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { routing } from './i18n/routing';
 
 const handleI18nRouting = createMiddleware(routing);
 
 export default async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Collapse accidental repeated slashes (e.g. from an old locale switcher bug).
+  if (pathname.includes('//')) {
+    const url = request.nextUrl.clone();
+    url.pathname = pathname.replace(/\/{2,}/g, '/');
+    return NextResponse.redirect(url);
+  }
+
   return handleI18nRouting(request);
 }
 

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -40,7 +40,7 @@
     "@types/node": "20.19.37",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "next-intl": "4.8.3",
+    "next-intl": "4.13.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tsdown": "0.21.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 16.3.0
         version: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
-        specifier: 4.13.0
-        version: 4.13.0(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: 4.13.6
+        version: 4.13.6(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -135,8 +135,8 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
       use-intl:
-        specifier: ^4.13.0
-        version: 4.13.0(react@19.2.4)
+        specifier: ^4.13.6
+        version: 4.13.6(react@19.2.4)
       zod:
         specifier: ^4
         version: 4.3.6
@@ -472,8 +472,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       next-intl:
-        specifier: 4.8.3
-        version: 4.8.3(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: 4.13.6
+        version: 4.13.6(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -5953,11 +5953,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  icu-minify@4.13.0:
-    resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
-
-  icu-minify@4.8.3:
-    resolution: {integrity: sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==}
+  icu-minify@4.13.6:
+    resolution: {integrity: sha512-iYZGCJZ+kX6o7GrxpVe2sOSdW86AvEqh8RQBvWeBd9jqmuABsMc2B6xongACfItLOogyIWH6GuBslNHr79OU8Q==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -6788,28 +6785,15 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-intl-swc-plugin-extractor@4.13.0:
-    resolution: {integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==}
+  next-intl-swc-plugin-extractor@4.13.6:
+    resolution: {integrity: sha512-M2L8jtPEAXj0CPmXbiW66THdr3OnDqA9IsU1hqv3CdxtVow3Bl9eXPdT9Opeji7L4AFrUZ016dJOs+CoTw66OA==}
 
-  next-intl-swc-plugin-extractor@4.8.3:
-    resolution: {integrity: sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==}
-
-  next-intl@4.13.0:
-    resolution: {integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==}
+  next-intl@4.13.6:
+    resolution: {integrity: sha512-loS6tjWWkr/IP+EV1yXUm9URB54QmZOp4+ZsMZNmeYxY8IZxLvO2esUegnXIDxj5DpK/4BsxwDGfGhlqodpkCQ==}
     peerDependencies:
       next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
       typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  next-intl@4.8.3:
-    resolution: {integrity: sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==}
-    peerDependencies:
-      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
-      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8169,8 +8153,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-intl@4.13.0:
-    resolution: {integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==}
+  use-intl@4.13.6:
+    resolution: {integrity: sha512-RLej84qL6PGTDp/PSG3tqRpwr7IvJfOu4Qfv/uyy8CrnYn1oEOQb6osNJb++jZ7FQxqN3aQ5BI7wTIerUgrgMA==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
@@ -13730,13 +13714,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icu-minify@4.13.0:
+  icu-minify@4.13.6:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.3
-
-  icu-minify@4.8.3:
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 3.5.1
 
   ignore@5.3.2: {}
 
@@ -14757,39 +14737,20 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-intl-swc-plugin-extractor@4.13.0: {}
+  next-intl-swc-plugin-extractor@4.13.6: {}
 
-  next-intl-swc-plugin-extractor@4.8.3: {}
-
-  next-intl@4.13.0(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.13.6(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
-      icu-minify: 4.13.0
+      icu-minify: 4.13.6
       negotiator: 1.0.0
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-intl-swc-plugin-extractor: 4.13.0
+      next-intl-swc-plugin-extractor: 4.13.6
       po-parser: 2.1.1
       react: 19.2.4
-      use-intl: 4.13.0(react@19.2.4)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  next-intl@4.8.3(next@16.3.0(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
-    dependencies:
-      '@formatjs/intl-localematcher': 0.8.1
-      '@parcel/watcher': 2.5.6
-      '@swc/core': 1.15.18
-      icu-minify: 4.8.3
-      negotiator: 1.0.0
-      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-intl-swc-plugin-extractor: 4.8.3
-      po-parser: 2.1.1
-      react: 19.2.4
-      use-intl: 4.13.0(react@19.2.4)
+      use-intl: 4.13.6(react@19.2.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16487,11 +16448,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-intl@4.13.0(react@19.2.4):
+  use-intl@4.13.6(react@19.2.4):
     dependencies:
       '@formatjs/fast-memoize': 3.1.1
       '@schummar/icu-type-parser': 1.21.5
-      icu-minify: 4.13.0
+      icu-minify: 4.13.6
       intl-messageformat: 11.1.2
       react: 19.2.4
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #12

## Summary

Upgrade `next-intl` to **4.13.6** and migrate off the deprecated `setRequestLocale` / `requestLocale` APIs to Next.js 16.3 `next/root-params`, per [the next-intl blog post](https://next-intl.dev/blog/nextjs-root-params).

## Changes

- Bump `next-intl` to `4.13.6` in `apps/codehouse` and `packages/toolbox` (aligned `use-intl`)
- Resolve locale in `i18n/request.ts` via `next/root-params` (keep explicit `locale` override for Server Actions / Route Handlers)
- Remove all `setRequestLocale` calls from layouts and pages
- Use `getLocale()` in nested layouts for `CachedPageContent` cache tags
- Unknown locales now call `notFound()` instead of falling back to the default locale
- Fix locale switcher stacking path slashes (`href={\`/\${pathname}\`}` → `href={pathname}`)
- Normalize repeated `//` path segments in `proxy.ts` so bad URLs heal

## Verification

- `pnpm --filter codehouse build` succeeded (TypeScript + static generation)
- Manual browser test: repeated EN↔NL switches on `/consumer` keep a clean URL
- `/nl/////consumer` normalizes to `/nl/consumer`

## Test plan

- [x] `pnpm --filter codehouse build` succeeds
- [x] Locale routing works for `/en` and `/nl`
- [x] Language switcher still switches locales
- [x] Nested routes (`/consumer`, `/freelance`, `/commercial`) render with correct translations
- [x] Locale switcher does not append extra slashes on repeated switches
- [x] Invalid locale paths return 404

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a7b911-0bce-419a-98ef-464af4531fb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a7b911-0bce-419a-98ef-464af4531fb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

